### PR TITLE
Add Python 3.8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,4 +100,6 @@ workflows:
               python_version:
                 - "3.6.7"
                 - "3.7.2"
+                - "3.8.2" # Ubuntu 20.04 LTS
+                - "3.8.3" # Latest version
       - dist

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
             'docs',
             'tests*',
         ]),
-    python_requires='>=3.6, <3.8',
+    python_requires='>=3.6, <3.9',
     include_package_data=True,
     package_data=_package_data,
     install_requires=[
@@ -83,5 +83,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -5,7 +5,7 @@ from fd_dj_accounts import models
 
 
 def generate_email_address() -> str:
-    return 'user-{}@example.com'.format(time.clock())
+    return 'user-{}@example.com'.format(time.process_time())
 
 
 def create_user(**kwargs: Any) -> models.User:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-    py36
-    py37
+    py36,
+    py37,
+    py38,
 
 [testenv]
 setenv =
@@ -10,5 +11,6 @@ commands = coverage run --rcfile=setup.cfg runtests.py tests
 deps =
     -r{toxinidir}/requirements_test.txt
 basepython =
-    py37: python3.7
     py36: python3.6
+    py37: python3.7
+    py38: python3.8


### PR DESCRIPTION
- Add version to Setuptools script.
- Add Tox environment.
- Add version to CI configuration.

More info: https://docs.python.org/3.8/whatsnew/3.8.html