### PR TITLE
config: Upgrade PostgreSQL to v12.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - image: python:<< parameters.python_version >>
 
       # Service container available at `host: localhost`.
-      - image: circleci/postgres:9.6
+      - image: circleci/postgres:12.3
         environment:
           POSTGRES_USER: django_dev
           POSTGRES_PASSWORD: django_dev


### PR DESCRIPTION
Change the PostgreSQL version used for CI to match the version used by the production server `apps-prod-v2` (12.3 since 2020-06-04).