### PR TITLE
config: Make CI 'dist' job depend on 'test' jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,9 @@ workflows:
                 - "3.6.12"
                 - "3.7.9"
                 - "3.8.6"
-      - dist
+      - dist:
+          requires:
+            - test
       - deploy:
           requires:
             - dist


### PR DESCRIPTION
CI workflows will finish faster if we do not attempt to build distributable artifacts when tests fail.