### PR TITLE
chore: Remove dependabot `time` and `timezone` params

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
     directory: /
     schedule:
       interval: monthly
-      time: "08:30"
-      timezone: America/Santiago
     open-pull-requests-limit: 3
     labels:
       - dependencies


### PR DESCRIPTION
Ref: https://github.com/fyntex/fd-django-accounts/pull/169#pullrequestreview-1078160008
Ref: https://cordada.aha.io/features/TECHINFRA-111
Ref: https://github.com/cordada/infra/issues/40