### PR TITLE
chore: Drop support for Python 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,6 @@ workflows:
           matrix:
             parameters:
               python_version:
-                - "3.6.12"
                 - "3.7.9"
                 - "3.8.6"
       - dist:

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,5 @@ upload-release: ## upload dist packages
 
 docker-compose-run-test: export COMPOSE_FILE = docker-compose.yml:docker-compose.test.yml
 docker-compose-run-test:  ## Run tests with Docker Compose
-	docker-compose run --rm -- app-python3.6
 	docker-compose run --rm -- app-python3.7
 	docker-compose run --rm -- app-python3.8

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -22,10 +22,6 @@ services:
         source: .
         target: /opt/app
 
-  app-python3.6:
-    <<: *services-app
-    image: docker.io/library/python:3.6.12
-
   app-python3.7:
     <<: *services-app
     image: docker.io/library/python:3.7.9

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py36,
     py37,
     py38,
 
@@ -11,6 +10,5 @@ commands = coverage run --rcfile=setup.cfg runtests.py tests
 deps =
     -r{toxinidir}/requirements_test.txt
 basepython =
-    py36: python3.6
     py37: python3.7
     py38: python3.8


### PR DESCRIPTION
Python 3.6 support ended on 2021-12-23
In order to keep all dependencies updated is needed to drop support of this version in the repository

Ref: https://cordada.aha.io/features/COMPCLDATA-123