### PR TITLE
Release v0.2.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.3
+current_version = 0.1.4
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.4
+current_version = 0.2.0
 commit = True
 tag = True
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,9 @@ workflows:
                 - "3.6.12"
                 - "3.7.9"
                 - "3.8.6"
-      - dist
+      - dist:
+          requires:
+            - test
       - deploy:
           requires:
             - dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,13 +55,7 @@ jobs:
             . venv/bin/activate
             pip install --upgrade pip
             pip install --upgrade setuptools wheel
-            pip install -r requirements_test.txt
-
-      - run:
-          name: Check Dependencies
-          command: |
-            . venv/bin/activate
-            pip check
+            make install-dev
 
       - run:
           name: run tests
@@ -100,13 +94,7 @@ jobs:
             . venv/bin/activate
             pip install --upgrade pip
             pip install --upgrade setuptools wheel
-            pip install -r requirements_release.txt
-
-      - run:
-          name: Check Dependencies
-          command: |
-            . venv/bin/activate
-            pip check
+            make install-dev
 
       - run:
           name: make dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,6 @@ workflows:
           matrix:
             parameters:
               python_version:
-                - "3.6.12"
                 - "3.7.9"
                 - "3.8.6"
       - dist:

--- a/.example.env
+++ b/.example.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=fd-django-accounts

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
     directory: /
     schedule:
       interval: monthly
-      time: "08:30"
-      timezone: America/Santiago
     open-pull-requests-limit: 3
     labels:
       - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   - package-ecosystem: pip
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
       time: "08:30"
       timezone: America/Santiago
     open-pull-requests-limit: 3

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,22 @@ History
 unreleased (YYYY-MM-DD)
 +++++++++++++++++++++++
 
+0.2.0 (2022-09-22)
+++++++++++++++++++
+
+- (PR #174, 2022-08-19) chore(management): Improve management command `createsuperuser`
+- (PR #176, 2022-08-29) chore: Add Make tasks for installation
+- (PR #138, 2022-08-31) build(deps): bump wheel from 0.36.2 to 0.37.1
+- (PR #178, 2022-09-05) Add testing with Docker Compose
+- (PR #177, 2022-09-05) build(deps): bump tox from 3.24.5 to 3.25.1
+- (PR #179, 2022-09-06) chore: Drop support for Python 3.6
+- (PR #167, 2022-09-06) chore(deps): bump coverage from 5.4 to 6.4.4
+- (PR #180, 2022-09-06) build(deps): bump mypy from 0.910 to 0.971
+- (PR #175, 2022-09-08) chore(deps): bump setuptools from 53.0.0 to 65.3.0
+- (PR #182, 2022-09-22) build(deps): bump twine from 3.3.0 to 4.0.1
+- (PR #181, 2022-09-22) chore(deps): bump psycopg2 from 2.8.6 to 2.9.3
+- (PR #183, 2022-09-22) chore(deps): bump tox from 3.25.1 to 3.26.0
+
 0.1.4 (2022-08-19)
 ++++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,35 @@ History
 unreleased (YYYY-MM-DD)
 +++++++++++++++++++++++
 
+0.1.4 (2022-08-19)
+++++++++++++++++++
+
+- (PR #44, 2020-09-16) build(deps): bump codecov from 2.1.7 to 2.1.9
+- (PR #42, 2020-09-16) build(deps): bump coverage from 5.2 to 5.3
+- (PR #43, 2020-09-17) build(deps): bump psycopg2 from 2.8.5 to 2.8.6
+- (PR #45, 2020-09-17) build(deps): bump wheel from 0.34.2 to 0.35.1
+- (PR #47, 2020-10-19) build(deps): bump tox from 3.20.0 to 3.20.1
+- (PR #46, 2020-10-19) build(deps): bump flake8 from 3.8.3 to 3.8.4
+- (PR #48, 2020-10-19) build(deps): bump mypy from 0.782 to 0.790
+- (PR #50, 2020-11-12) build(deps): bump codecov from 2.1.9 to 2.1.10
+- (PR #49, 2020-11-12) build(deps): bump setuptools from 50.3.0 to 50.3.2
+- (PR #53, 2020-12-15) build(deps): bump setuptools from 50.3.2 to 51.0.0
+- (PR #54, 2020-12-15) build(deps): bump wheel from 0.35.1 to 0.36.2
+- (PR #55, 2020-12-15) Update Python 3.6, 3.7, and 3.8 versions
+- (PR #56, 2020-12-15) config: Make CI 'dist' job depend on 'test' jobs
+- (PR #58, 2020-12-22) build(deps): bump coverage from 5.3 to 5.3.1
+- (PR #61, 2020-12-30) build(deps): bump twine from 3.2.0 to 3.3.0
+- (PR #57, 2020-12-30) build(deps): bump codecov from 2.1.10 to 2.1.11
+- (PR #73, 2021-02-16) build(deps): bump tox from 3.20.1 to 3.22.0
+- (PR #71, 2021-02-16) build(deps): bump setuptools from 51.0.0 to 53.0.0
+- (PR #69, 2021-02-16) build(deps): bump mypy from 0.790 to 0.800
+- (PR #74, 2021-02-16) build(deps): bump coverage from 5.3.1 to 5.4
+- (PR #88, 2021-10-13) build(deps): bump mypy from 0.800 to 0.910
+- (PR #119, 2022-03-25) build(deps): bump tox from 3.22.0 to 3.24.5
+- (PR #169, 2022-08-18) chore: Change Dependabot schedule interval from `daily` to `monthly`
+- (PR #172, 2022-08-19) feat(management): Add management command `createsuperuser`
+- (PR #171, 2022-08-19) chore: Remove dependabot `time` and `timezone` params
+
 0.1.3 (2020-09-15)
 ++++++++++++++++++
 

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,5 @@ upload-release: ## upload dist packages
 
 docker-compose-run-test: export COMPOSE_FILE = docker-compose.yml:docker-compose.test.yml
 docker-compose-run-test:  ## Run tests with Docker Compose
-	docker-compose run --rm -- app-python3.6
 	docker-compose run --rm -- app-python3.7
 	docker-compose run --rm -- app-python3.8

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SHELL = /usr/bin/env bash
 .DEFAULT_GOAL := help
 .PHONY: help
 .PHONY: clean clean-build clean-pyc clean-test
+.PHONY: install-dev install-deps-dev
 .PHONY: lint test test-all test-coverage test-coverage-report-console test-coverage-report-html
 .PHONY: docs dist upload-release
 
@@ -34,6 +35,21 @@ clean-test: ## remove test, lint and coverage artifacts
 	rm -rf htmlcov/
 	rm -rf test-reports/
 	rm -rf .mypy_cache/
+
+install-dev: install-deps-dev
+install-dev: ## Install for development
+	python -m pip install --editable .
+	python -m pip check
+
+install-deps-dev: ## Install dependencies for development
+	python -m pip install -r requirements.txt
+	python -m pip check
+
+	python -m pip install -r requirements_test.txt
+	python -m pip check
+
+	python -m pip install -r requirements_release.txt
+	python -m pip check
 
 lint: ## run tools for code style analysis, static type check, etc
 	flake8  --config=setup.cfg  fd_dj_accounts  tests

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SHELL = /usr/bin/env bash
 .PHONY: install-dev install-deps-dev
 .PHONY: lint test test-all test-coverage test-coverage-report-console test-coverage-report-html
 .PHONY: docs dist upload-release
+.PHONY: docker-compose-run-test
 
 help:
 	@grep '^[a-zA-Z]' $(MAKEFILE_LIST) | sort | awk -F ':.*?## ' 'NF==2 {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
@@ -85,3 +86,9 @@ dist: clean ## builds source and wheel package
 
 upload-release: ## upload dist packages
 	python -m twine upload 'dist/*'
+
+docker-compose-run-test: export COMPOSE_FILE = docker-compose.yml:docker-compose.test.yml
+docker-compose-run-test:  ## Run tests with Docker Compose
+	docker-compose run --rm -- app-python3.6
+	docker-compose run --rm -- app-python3.7
+	docker-compose run --rm -- app-python3.8

--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,10 @@ code style analysis, static type check, etc::
     make test-all
     make lint
 
+(same as above, but with Docker Compose)::
+
+    make docker-compose-run-test
+
 Check code coverage of tests::
 
     make test-coverage

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ Tests
 
 Requirements::
 
-    pip install -r requirements_test.txt
+    make install-dev
 
 Run test suite for all supported Python versions and run tools for
 code style analysis, static type check, etc::

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,42 @@
+# Docker Compose Configuration for Test Environment
+
+version: "3.9"
+
+services:
+  app: &services-app
+    image: docker.io/library/python:3
+    command: ["make", "install-dev", "lint", "test"]
+    working_dir: /opt/app
+    environment:
+      - DATABASE_HOST=${DATABASE_HOST:-db-test}
+      - DATABASE_NAME=${DATABASE_NAME:-app_test}
+      - DATABASE_PASSWORD=${DATABASE_PASSWORD:-123}
+      - DATABASE_PORT=${DATABASE_PORT:-5432}
+      - DATABASE_USERNAME=${DATABASE_USERNAME:-app}
+      - PYTHONBREAKPOINT
+      - PYTHONDONTWRITEBYTECODE=true
+    depends_on:
+      - db-test
+    volumes:
+      - type: bind
+        source: .
+        target: /opt/app
+
+  app-python3.6:
+    <<: *services-app
+    image: docker.io/library/python:3.6.12
+
+  app-python3.7:
+    <<: *services-app
+    image: docker.io/library/python:3.7.9
+
+  app-python3.8:
+    <<: *services-app
+    image: docker.io/library/python:3.8.6
+
+  db-test:
+    image: docker.io/library/postgres:12.3
+    environment:
+      POSTGRES_DB: app_test
+      POSTGRES_PASSWORD: "123"
+      POSTGRES_USER: app

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -22,10 +22,6 @@ services:
         source: .
         target: /opt/app
 
-  app-python3.6:
-    <<: *services-app
-    image: docker.io/library/python:3.6.12
-
   app-python3.7:
     <<: *services-app
     image: docker.io/library/python:3.7.9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+# Docker Compose Base Configuration
+
+# > Understanding multiple Compose files
+# >
+# > By default, Compose reads two files, a `docker-compose.yml` and an optional
+# > `docker-compose.override.yml` file. By convention, the `docker-compose.yml` contains your base
+# > configuration. The override file, as its name implies, can contain configuration overrides for
+# > existing services or entirely new services.
+# >
+# > If a service is defined in both files, Compose merges the configurations using the rules
+# > described in Adding and overriding configuration.
+#
+# Source: https://docs.docker.com/compose/extends/#understanding-multiple-compose-files
+
+version: "3.9"
+
+services:
+  app: &services-app
+    depends_on: []
+    env_file: []
+    environment: []
+    ports: []
+    volumes: []
+
+volumes: {}

--- a/fd_dj_accounts/__init__.py
+++ b/fd_dj_accounts/__init__.py
@@ -98,7 +98,7 @@ About customization of the Django user model
 """
 
 
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 
 
 default_app_config = 'fd_dj_accounts.apps.AccountsAppConfig'

--- a/fd_dj_accounts/__init__.py
+++ b/fd_dj_accounts/__init__.py
@@ -98,7 +98,7 @@ About customization of the Django user model
 """
 
 
-__version__ = '0.1.4'
+__version__ = '0.2.0'
 
 
 default_app_config = 'fd_dj_accounts.apps.AccountsAppConfig'

--- a/fd_dj_accounts/management/__init__.py
+++ b/fd_dj_accounts/management/__init__.py
@@ -1,0 +1,16 @@
+from django.db import DEFAULT_DB_ALIAS
+
+
+def get_default_username(check_db: bool = True, database: str = DEFAULT_DB_ALIAS) -> str:
+    """
+    Try to determine the current system user's username to use as a default.
+
+    :param check_db: If ``True``, requires that the username does not match an
+        existing ``auth.User`` (otherwise returns an empty string).
+    :param database: The database where the unique check will be performed.
+    :returns: The username, or an empty string if no username can be
+        determined or the suggested username is already taken.
+    """
+    # TODO: Implement as closely as possible to
+    #  ``django.contrib.auth.management.get_default_username()``.
+    return ''  # No username can be determined.

--- a/fd_dj_accounts/management/commands/createsuperuser.py
+++ b/fd_dj_accounts/management/commands/createsuperuser.py
@@ -1,0 +1,171 @@
+"""
+Management utility to create superusers.
+"""
+
+import getpass
+import os
+import sys
+from typing import Any, MutableMapping
+
+import django.contrib.auth.management.commands.createsuperuser
+import django.core.management.base
+from django.contrib.auth.management.commands.createsuperuser import (
+    PASSWORD_FIELD,
+    NotRunningInTTYException,
+)
+from django.contrib.auth.password_validation import validate_password
+from django.core import exceptions
+from django.core.management.base import CommandError
+from django.db import DEFAULT_DB_ALIAS
+from django.utils.text import capfirst
+
+
+def get_default_username(check_db: bool = True, database: str = DEFAULT_DB_ALIAS) -> str:
+    """
+    Try to determine the current system user's username to use as a default.
+
+    :param check_db: If ``True``, requires that the username does not match an
+        existing ``auth.User`` (otherwise returns an empty string).
+    :param database: The database where the unique check will be performed.
+    :returns: The username, or an empty string if no username can be
+        determined or the suggested username is already taken.
+    """
+    # TODO: Implement as closely as possible to
+    #  ``django.contrib.auth.management.get_default_username()``.
+    return ''  # No username can be determined.
+
+
+class Command(django.contrib.auth.management.commands.createsuperuser.Command):
+    def handle(self, *args: Any, **options: Any) -> None:
+        # Note: This method was copied as-is from
+        #  ``django.contrib.auth.management.commands.createsuperuser.Command.handle()``
+        #  (Django 3.2.15) because we had to override ``get_default_username()``.
+        #  The only modification is that type annotations were added.
+
+        username = options[self.UserModel.USERNAME_FIELD]
+        database = options['database']
+        user_data: MutableMapping[str, object] = {}
+        verbose_field_name = self.username_field.verbose_name
+        try:
+            self.UserModel._meta.get_field(PASSWORD_FIELD)
+        except exceptions.FieldDoesNotExist:
+            pass
+        else:
+            # If not provided, create the user with an unusable password.
+            user_data[PASSWORD_FIELD] = None
+        try:
+            if options['interactive']:
+                # Same as user_data but without many to many fields and with
+                # foreign keys as fake model instances instead of raw IDs.
+                fake_user_data = {}
+                if hasattr(self.stdin, 'isatty') and not self.stdin.isatty():
+                    raise NotRunningInTTYException
+                default_username = get_default_username(database=database)
+                if username:
+                    error_msg = self._validate_username(username, verbose_field_name, database)
+                    if error_msg:
+                        self.stderr.write(error_msg)
+                        username = None
+                elif username == '':
+                    raise CommandError('%s cannot be blank.' % capfirst(verbose_field_name))
+                # Prompt for username.
+                while username is None:
+                    message = self._get_input_message(self.username_field, default_username)
+                    username = self.get_input_data(self.username_field, message, default_username)
+                    if username:
+                        error_msg = self._validate_username(username, verbose_field_name, database)
+                        if error_msg:
+                            self.stderr.write(error_msg)
+                            username = None
+                            continue
+                user_data[self.UserModel.USERNAME_FIELD] = username
+                fake_user_data[self.UserModel.USERNAME_FIELD] = (
+                    self.username_field.remote_field.model(username)
+                    if self.username_field.remote_field else username
+                )
+                # Prompt for required fields.
+                for field_name in self.UserModel.REQUIRED_FIELDS:
+                    field = self.UserModel._meta.get_field(field_name)
+                    user_data[field_name] = options[field_name]
+                    while user_data[field_name] is None:
+                        message = self._get_input_message(field)
+                        input_value = self.get_input_data(field, message)
+                        user_data[field_name] = input_value
+                        if field.many_to_many and input_value:
+                            if not input_value.strip():
+                                user_data[field_name] = None
+                                self.stderr.write('Error: This field cannot be blank.')
+                                continue
+                            user_data[field_name] = [pk.strip() for pk in input_value.split(',')]
+                        if not field.many_to_many:
+                            fake_user_data[field_name] = input_value
+
+                        # Wrap any foreign keys in fake model instances
+                        if field.many_to_one:
+                            fake_user_data[field_name] = field.remote_field.model(input_value)
+
+                # Prompt for a password if the model has one.
+                while PASSWORD_FIELD in user_data and user_data[PASSWORD_FIELD] is None:
+                    password = getpass.getpass()
+                    password2 = getpass.getpass('Password (again): ')
+                    if password != password2:
+                        self.stderr.write("Error: Your passwords didn't match.")
+                        # Don't validate passwords that don't match.
+                        continue
+                    if password.strip() == '':
+                        self.stderr.write("Error: Blank passwords aren't allowed.")
+                        # Don't validate blank passwords.
+                        continue
+                    try:
+                        validate_password(password2, self.UserModel(**fake_user_data))
+                    except exceptions.ValidationError as err:
+                        self.stderr.write('\n'.join(err.messages))
+                        response = input(
+                            'Bypass password validation and create user anyway? [y/N]: '
+                        )
+                        if response.lower() != 'y':
+                            continue
+                    user_data[PASSWORD_FIELD] = password
+            else:
+                # Non-interactive mode.
+                # Use password from environment variable, if provided.
+                if PASSWORD_FIELD in user_data and 'DJANGO_SUPERUSER_PASSWORD' in os.environ:
+                    user_data[PASSWORD_FIELD] = os.environ['DJANGO_SUPERUSER_PASSWORD']
+                # Use username from environment variable, if not provided in
+                # options.
+                if username is None:
+                    username = os.environ.get(
+                        'DJANGO_SUPERUSER_' + self.UserModel.USERNAME_FIELD.upper()
+                    )
+                if username is None:
+                    raise CommandError(
+                        'You must use --%s with --noinput.' % self.UserModel.USERNAME_FIELD
+                    )
+                else:
+                    error_msg = self._validate_username(username, verbose_field_name, database)
+                    if error_msg:
+                        raise CommandError(error_msg)
+
+                user_data[self.UserModel.USERNAME_FIELD] = username
+                for field_name in self.UserModel.REQUIRED_FIELDS:
+                    env_var = 'DJANGO_SUPERUSER_' + field_name.upper()
+                    value = options[field_name] or os.environ.get(env_var)
+                    if not value:
+                        raise CommandError('You must use --%s with --noinput.' % field_name)
+                    field = self.UserModel._meta.get_field(field_name)
+                    user_data[field_name] = field.clean(value, None)
+
+            self.UserModel._default_manager.db_manager(database).create_superuser(**user_data)
+            if options['verbosity'] >= 1:
+                self.stdout.write("Superuser created successfully.")
+        except KeyboardInterrupt:
+            self.stderr.write('\nOperation cancelled.')
+            sys.exit(1)
+        except exceptions.ValidationError as e:
+            raise CommandError('; '.join(e.messages))
+        except NotRunningInTTYException:
+            self.stdout.write(
+                'Superuser creation skipped due to not running in a TTY. '
+                'You can run `manage.py createsuperuser` in your project '
+                'to create one manually.'
+            )

--- a/fd_dj_accounts/management/commands/createsuperuser.py
+++ b/fd_dj_accounts/management/commands/createsuperuser.py
@@ -16,23 +16,9 @@ from django.contrib.auth.management.commands.createsuperuser import (
 from django.contrib.auth.password_validation import validate_password
 from django.core import exceptions
 from django.core.management.base import CommandError
-from django.db import DEFAULT_DB_ALIAS
 from django.utils.text import capfirst
 
-
-def get_default_username(check_db: bool = True, database: str = DEFAULT_DB_ALIAS) -> str:
-    """
-    Try to determine the current system user's username to use as a default.
-
-    :param check_db: If ``True``, requires that the username does not match an
-        existing ``auth.User`` (otherwise returns an empty string).
-    :param database: The database where the unique check will be performed.
-    :returns: The username, or an empty string if no username can be
-        determined or the suggested username is already taken.
-    """
-    # TODO: Implement as closely as possible to
-    #  ``django.contrib.auth.management.get_default_username()``.
-    return ''  # No username can be determined.
+from fd_dj_accounts.management import get_default_username
 
 
 class Command(django.contrib.auth.management.commands.createsuperuser.Command):

--- a/requirements_release.txt
+++ b/requirements_release.txt
@@ -2,5 +2,5 @@
 
 bumpversion==0.5.3
 setuptools==51.0.0
-twine==3.2.0
+twine==3.3.0
 wheel==0.36.2

--- a/requirements_release.txt
+++ b/requirements_release.txt
@@ -2,5 +2,5 @@
 
 bumpversion==0.5.3
 setuptools==65.3.0
-twine==3.3.0
+twine==4.0.1
 wheel==0.37.1

--- a/requirements_release.txt
+++ b/requirements_release.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
 bumpversion==0.5.3
-setuptools==51.0.0
+setuptools==53.0.0
 twine==3.3.0
 wheel==0.36.2

--- a/requirements_release.txt
+++ b/requirements_release.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
 bumpversion==0.5.3
-setuptools==53.0.0
+setuptools==65.3.0
 twine==3.3.0
 wheel==0.37.1

--- a/requirements_release.txt
+++ b/requirements_release.txt
@@ -3,4 +3,4 @@
 bumpversion==0.5.3
 setuptools==53.0.0
 twine==3.3.0
-wheel==0.36.2
+wheel==0.37.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,4 +5,4 @@ coverage==6.4.4
 flake8==3.8.4
 mypy==0.971
 psycopg2==2.9.3 --no-binary psycopg2
-tox==3.25.1
+tox==3.26.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,5 +4,5 @@ codecov==2.1.11
 coverage==6.4.4
 flake8==3.8.4
 mypy==0.971
-psycopg2==2.8.6 --no-binary psycopg2
+psycopg2==2.9.3 --no-binary psycopg2
 tox==3.25.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,6 +3,6 @@
 codecov==2.1.11
 coverage==6.4.4
 flake8==3.8.4
-mypy==0.910
+mypy==0.971
 psycopg2==2.8.6 --no-binary psycopg2
 tox==3.25.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 
 codecov==2.1.11
-coverage==5.3.1
+coverage==5.4
 flake8==3.8.4
 mypy==0.800
 psycopg2==2.8.6 --no-binary psycopg2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 
 codecov==2.1.11
-coverage==5.4
+coverage==6.4.4
 flake8==3.8.4
 mypy==0.910
 psycopg2==2.8.6 --no-binary psycopg2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 
 codecov==2.1.10
-coverage==5.3
+coverage==5.3.1
 flake8==3.8.4
 mypy==0.790
 psycopg2==2.8.6 --no-binary psycopg2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,4 +5,4 @@ coverage==5.3.1
 flake8==3.8.4
 mypy==0.790
 psycopg2==2.8.6 --no-binary psycopg2
-tox==3.20.1
+tox==3.22.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-codecov==2.1.10
+codecov==2.1.11
 coverage==5.3.1
 flake8==3.8.4
 mypy==0.790

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,4 +5,4 @@ coverage==5.4
 flake8==3.8.4
 mypy==0.910
 psycopg2==2.8.6 --no-binary psycopg2
-tox==3.24.5
+tox==3.25.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,6 +3,6 @@
 codecov==2.1.11
 coverage==5.3.1
 flake8==3.8.4
-mypy==0.790
+mypy==0.800
 psycopg2==2.8.6 --no-binary psycopg2
 tox==3.22.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,4 +5,4 @@ coverage==5.4
 flake8==3.8.4
 mypy==0.910
 psycopg2==2.8.6 --no-binary psycopg2
-tox==3.22.0
+tox==3.24.5

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,6 +3,6 @@
 codecov==2.1.11
 coverage==5.4
 flake8==3.8.4
-mypy==0.800
+mypy==0.910
 psycopg2==2.8.6 --no-binary psycopg2
 tox==3.22.0

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,3 +1,5 @@
+import os
+
 import django  # noqa: F401
 
 DEBUG = False
@@ -10,11 +12,11 @@ SECRET_KEY = "^e8thszumk=vywe=-9!6aizo^+h*rf2v8$88*_*@^194&-^3)n"
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'HOST': 'localhost',
-        'PORT': 5432,
-        'NAME': 'accounts_dev',
-        'USER': 'django_dev',
-        'PASSWORD': 'django_dev',
+        'HOST': os.getenv('DATABASE_HOST', 'localhost'),
+        'PORT': int(os.getenv('DATABASE_PORT', '5432')),
+        'NAME': os.getenv('DATABASE_NAME', 'accounts_dev'),
+        'USER': os.getenv('DATABASE_USERNAME', 'django_dev'),
+        'PASSWORD': os.getenv('DATABASE_PASSWORD', 'django_dev'),
         'ATOMIC_REQUESTS': False,
         'AUTOCOMMIT': True,
     }

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -3,19 +3,38 @@ from io import StringIO
 from django.core.management import call_command
 from django.test import TestCase
 
+from fd_dj_accounts import management
+from fd_dj_accounts.models import User
+
+
+class GetDefaultUsernameTestCase(TestCase):
+    def test_simple(self) -> None:
+        self.assertEqual(management.get_default_username(), '')
+
+    # TODO: Add tests.
+    #   See: https://github.com/django/django/blob/3.2/tests/auth_tests/test_management.py#L104-L139
+
 
 class CreatesuperuserManagementCommandTestCase(TestCase):
-    def test_command_minimal(self) -> None:
+    def test_basic_usage(self) -> None:
+        """
+        Check the operation of the createsuperuser management command
+        """
+        # We can use the management command to create a superuser
         new_io = StringIO()
-
         call_command(
             'createsuperuser',
             interactive=False,
             email_address='staff@example.com',
-            verbosity=0,
-            stdout=new_io,
-            stderr=new_io,
+            stdout=new_io
         )
+        command_output = new_io.getvalue().strip()
+        self.assertEqual(command_output, 'Superuser created successfully.')
+        u = User.objects.get(email_address='staff@example.com')
+        self.assertEqual(u.get_username(), 'staff@example.com')
+
+        # created password should be unusable
+        self.assertFalse(u.has_usable_password())
 
     # TODO: Add tests.
     #   See:

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1,0 +1,23 @@
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class CreatesuperuserManagementCommandTestCase(TestCase):
+    def test_command_minimal(self) -> None:
+        new_io = StringIO()
+
+        call_command(
+            'createsuperuser',
+            interactive=False,
+            email_address='staff@example.com',
+            verbosity=0,
+            stdout=new_io,
+            stderr=new_io,
+        )
+
+    # TODO: Add tests.
+    #   See:
+    #   - https://github.com/django/django/blob/3.2/tests/auth_tests/test_management.py#L253-L1036
+    #   - https://github.com/django/django/blob/3.2/tests/auth_tests/test_management.py#L1039-L1088

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py36,
     py37,
     py38,
 
@@ -11,6 +10,5 @@ commands = coverage run --rcfile=setup.cfg runtests.py tests
 deps =
     -r{toxinidir}/requirements_test.txt
 basepython =
-    py36: python3.6
     py37: python3.7
     py38: python3.8


### PR DESCRIPTION
- (PR #174, 2022-08-19) chore(management): Improve management command `createsuperuser`
- (PR #176, 2022-08-29) chore: Add Make tasks for installation
- (PR #138, 2022-08-31) build(deps): bump wheel from 0.36.2 to 0.37.1
- (PR #178, 2022-09-05) Add testing with Docker Compose
- (PR #177, 2022-09-05) build(deps): bump tox from 3.24.5 to 3.25.1
- (PR #179, 2022-09-06) chore: Drop support for Python 3.6
- (PR #167, 2022-09-06) chore(deps): bump coverage from 5.4 to 6.4.4
- (PR #180, 2022-09-06) build(deps): bump mypy from 0.910 to 0.971
- (PR #175, 2022-09-08) chore(deps): bump setuptools from 53.0.0 to 65.3.0
- (PR #182, 2022-09-22) build(deps): bump twine from 3.3.0 to 4.0.1
- (PR #181, 2022-09-22) chore(deps): bump psycopg2 from 2.8.6 to 2.9.3
- (PR #183, 2022-09-22) chore(deps): bump tox from 3.25.1 to 3.26.0