### PR TITLE
feat: Add Python 3.9 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,7 @@ workflows:
               python_version:
                 - "3.7.9"
                 - "3.8.6"
+                - "3.9.15"
       - dist:
           requires:
             - test

--- a/Makefile
+++ b/Makefile
@@ -91,3 +91,4 @@ docker-compose-run-test: export COMPOSE_FILE = docker-compose.yml:docker-compose
 docker-compose-run-test:  ## Run tests with Docker Compose
 	docker-compose run --rm -- app-python3.7
 	docker-compose run --rm -- app-python3.8
+	docker-compose run --rm -- app-python3.9

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -30,6 +30,10 @@ services:
     <<: *services-app
     image: docker.io/library/python:3.8.6
 
+  app-python3.9:
+    <<: *services-app
+    image: docker.io/library/python:3.9.15
+
   db-test:
     image: docker.io/library/postgres:12.3
     environment:

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
             'docs',
             'tests*',
         ]),
-    python_requires='>=3.6, <3.9',
+    python_requires='>=3.7, <3.10',
     include_package_data=True,
     package_data=_package_data,
     install_requires=[
@@ -83,5 +83,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,4 @@ deps =
 basepython =
     py37: python3.7
     py38: python3.8
+    py39: python3.9


### PR DESCRIPTION
- Add version to Setuptools script.
- Add Tox environment.
- Add version to CI configuration.
- Update Docker Compose configuration.
- Update Make task for running tests: `docker-compose-run-test`.

More info: https://docs.python.org/3.9/whatsnew/3.9.html

Ref: https://cordada.aha.io/features/COMPCLDATA-162