### PR TITLE
fix(requirements): Pin importlib-metadata dependency for python 3.7

### DIFF
--- a/requirements_release.txt
+++ b/requirements_release.txt
@@ -4,3 +4,7 @@ bumpversion==0.5.3
 setuptools==65.3.0
 twine==4.0.1
 wheel==0.37.1
+
+importlib-metadata==4.13.0 ; python_version < "3.8"
+    # via
+    #   twine


### PR DESCRIPTION
The release v5.0.0 of `importlib-metadata` removed compatibility shims for deprecated entry point interfaces, which lead to the incompatibility in python 3.7

Pin `importlib-metadata` dependency to maintain CLI compatibility for python 3.7.

Changelog: https://importlib-metadata.readthedocs.io/en/latest/history.html#v5-0-0