### PR TITLE
Release v0.3.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.3.0
 commit = True
 tag = True
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,7 @@ workflows:
               python_version:
                 - "3.7.9"
                 - "3.8.6"
+                - "3.9.15"
       - dist:
           requires:
             - test

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,12 @@ History
 unreleased (YYYY-MM-DD)
 +++++++++++++++++++++++
 
+0.3.0 (2022-11-11)
+++++++++++++++++++
+
+- (PR #191, 2022-11-10) fix(requirements): Pin importlib-metadata dependency for python 3.7
+- (PR #190, 2022-11-11) feat: Add Python 3.9 support
+
 0.2.0 (2022-09-22)
 ++++++++++++++++++
 

--- a/Makefile
+++ b/Makefile
@@ -91,3 +91,4 @@ docker-compose-run-test: export COMPOSE_FILE = docker-compose.yml:docker-compose
 docker-compose-run-test:  ## Run tests with Docker Compose
 	docker-compose run --rm -- app-python3.7
 	docker-compose run --rm -- app-python3.8
+	docker-compose run --rm -- app-python3.9

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -30,6 +30,10 @@ services:
     <<: *services-app
     image: docker.io/library/python:3.8.6
 
+  app-python3.9:
+    <<: *services-app
+    image: docker.io/library/python:3.9.15
+
   db-test:
     image: docker.io/library/postgres:12.3
     environment:

--- a/fd_dj_accounts/__init__.py
+++ b/fd_dj_accounts/__init__.py
@@ -98,7 +98,7 @@ About customization of the Django user model
 """
 
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 
 
 default_app_config = 'fd_dj_accounts.apps.AccountsAppConfig'

--- a/requirements_release.txt
+++ b/requirements_release.txt
@@ -4,3 +4,7 @@ bumpversion==0.5.3
 setuptools==65.3.0
 twine==4.0.1
 wheel==0.37.1
+
+importlib-metadata==4.13.0 ; python_version < "3.8"
+    # via
+    #   twine

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
             'docs',
             'tests*',
         ]),
-    python_requires='>=3.6, <3.9',
+    python_requires='>=3.7, <3.10',
     include_package_data=True,
     package_data=_package_data,
     install_requires=[
@@ -83,5 +83,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,4 @@ deps =
 basepython =
     py37: python3.7
     py38: python3.8
+    py39: python3.9


### PR DESCRIPTION
- (PR #191, 2022-11-10) fix(requirements): Pin importlib-metadata dependency for python 3.7
- (PR #190, 2022-11-11) feat: Add Python 3.9 support