### PR TITLE
chore: Update `last_login` field on User model

### DIFF
--- a/fd_dj_accounts/models.py
+++ b/fd_dj_accounts/models.py
@@ -10,6 +10,25 @@ from django.db import models
 
 from . import base_models
 
+from django.contrib.auth.base_user import AbstractBaseUser
+from django.utils import timezone
+
+
+def update_last_login(sender: Any, user: AbstractBaseUser, **kwargs: Any) -> None:
+    """
+    A signal receiver which updates the last_login date for
+    the user logging in.
+
+    We are not able to use the original function (of which this one is a copy)
+    because we can not import :mod:`django.contrib.auth.models` without adding
+    ``django.contrib.auth`` to setting ``INSTALLED_APPS``.
+
+    Source: copy of :func:`django.contrib.auth.models.update_last_login` @ Django 2.1.1
+
+    """
+    user.last_login = timezone.now()
+    user.save(update_fields=['last_login'])
+
 
 def get_or_create_system_user() -> 'User':
     """Return the "system user", which is created by itself.

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,24 @@
+from django.contrib.auth import signals
+from django.test import TestCase
+from django.test.client import RequestFactory
+from fd_dj_accounts.models import User
+
+
+class SignalTestCase(TestCase):
+
+    def test_update_last_login(self) -> None:
+        """Only `last_login` is updated in `update_last_login`"""
+        user = User.objects.create_user(email_address='staff@a.com', password='password')
+        self.assertIsNone(user.last_login)
+
+        request = RequestFactory().get('/login')
+        signals.user_logged_in.send(sender=user.__class__, request=request, user=user)
+        self.assertIsNotNone(user.last_login)
+
+        old_last_login = user.last_login
+        request = RequestFactory().get('/login')
+        signals.user_logged_in.send(sender=user.__class__, request=request, user=user)
+        user.refresh_from_db()
+
+        self.assertEqual(user.get_username(), 'staff@a.com')
+        self.assertGreater(user.last_login, old_last_login)


### PR DESCRIPTION
Since in our project the method `django.contrib.auth.apps.AuthConfig.ready` will not be executed (because that app is not in `INSTALLED_APPS`) the function `django.contrib.auth.models.update_last_login` will not be registered to the signal `django.contrib.auth.signals.user_logged_in`.

Ref: https://cordada.aha.io/features/COMPCLDATA-179
Ref: https://github.com/fyntex/fd-secrets-manager/issues/28
Ref: https://github.com/fyntex/fd-django-accounts/issues/5