### PR TITLE
chore: Add support for Python 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
 
   dist:
     docker:
-      - image: python:3.7.2
+      - image: python:3.10.9
 
     working_directory: ~/repo
 
@@ -114,7 +114,7 @@ jobs:
 
   deploy:
     docker:
-      - image: python:3.7.2
+      - image: python:3.10.9
         environment:
           <<: *x-deploy-environment
 
@@ -146,6 +146,7 @@ workflows:
                 - "3.7.9"
                 - "3.8.6"
                 - "3.9.15"
+                - "3.10.9"
       - dist:
           requires:
             - test

--- a/Makefile
+++ b/Makefile
@@ -92,3 +92,4 @@ docker-compose-run-test:  ## Run tests with Docker Compose
 	docker-compose run --rm -- app-python3.7
 	docker-compose run --rm -- app-python3.8
 	docker-compose run --rm -- app-python3.9
+	docker-compose run --rm -- app-python3.10

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -34,6 +34,10 @@ services:
     <<: *services-app
     image: docker.io/library/python:3.9.15
 
+  app-python3.10:
+    <<: *services-app
+    image: docker.io/library/python:3.10.9
+
   db-test:
     image: docker.io/library/postgres:12.3
     environment:

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
             'docs',
             'tests*',
         ]),
-    python_requires='>=3.7, <3.10',
+    python_requires='>=3.7, <3.11',
     include_package_data=True,
     package_data=_package_data,
     install_requires=[
@@ -84,5 +84,6 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 envlist =
     py37,
     py38,
+    py39,
+    py310,
 
 [testenv]
 setenv =
@@ -13,3 +15,4 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10


### PR DESCRIPTION
* Add Python 3.10 to Setuptools script.
* Add Tox environment for Python 3.10.
* Add Python 3.10 to CircleCI configuration.
* Add Python 3.10 .black target-version
* Update `docker-compose.yml` file

More information: https://docs.python.org/3.10/whatsnew/3.10.html

Ref: https://cordada.aha.io/features/COMPCLDATA-163