### PR TITLE
Release v0.4.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,6 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.4.0
 commit = True
 tag = True
 
 [bumpversion:file:fd_dj_accounts/__init__.py]
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
 
   dist:
     docker:
-      - image: python:3.7.2
+      - image: python:3.10.9
 
     working_directory: ~/repo
 
@@ -114,7 +114,7 @@ jobs:
 
   deploy:
     docker:
-      - image: python:3.7.2
+      - image: python:3.10.9
         environment:
           <<: *x-deploy-environment
 
@@ -146,6 +146,7 @@ workflows:
                 - "3.7.9"
                 - "3.8.6"
                 - "3.9.15"
+                - "3.10.9"
       - dist:
           requires:
             - test

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,12 @@ History
 unreleased (YYYY-MM-DD)
 +++++++++++++++++++++++
 
+0.4.0 (2023-01-05)
+++++++++++++++++++
+
+- (PR #197, 2022-12-20) chore: Update `last_login` field on User model
+- (PR #199, 2023-01-04) chore: Add support for Python 3.10
+
 0.3.0 (2022-11-11)
 ++++++++++++++++++
 

--- a/Makefile
+++ b/Makefile
@@ -92,3 +92,4 @@ docker-compose-run-test:  ## Run tests with Docker Compose
 	docker-compose run --rm -- app-python3.7
 	docker-compose run --rm -- app-python3.8
 	docker-compose run --rm -- app-python3.9
+	docker-compose run --rm -- app-python3.10

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -34,6 +34,10 @@ services:
     <<: *services-app
     image: docker.io/library/python:3.9.15
 
+  app-python3.10:
+    <<: *services-app
+    image: docker.io/library/python:3.10.9
+
   db-test:
     image: docker.io/library/postgres:12.3
     environment:

--- a/fd_dj_accounts/__init__.py
+++ b/fd_dj_accounts/__init__.py
@@ -98,7 +98,7 @@ About customization of the Django user model
 """
 
 
-__version__ = '0.3.0'
+__version__ = '0.4.0'
 
 
 default_app_config = 'fd_dj_accounts.apps.AccountsAppConfig'

--- a/fd_dj_accounts/models.py
+++ b/fd_dj_accounts/models.py
@@ -10,6 +10,25 @@ from django.db import models
 
 from . import base_models
 
+from django.contrib.auth.base_user import AbstractBaseUser
+from django.utils import timezone
+
+
+def update_last_login(sender: Any, user: AbstractBaseUser, **kwargs: Any) -> None:
+    """
+    A signal receiver which updates the last_login date for
+    the user logging in.
+
+    We are not able to use the original function (of which this one is a copy)
+    because we can not import :mod:`django.contrib.auth.models` without adding
+    ``django.contrib.auth`` to setting ``INSTALLED_APPS``.
+
+    Source: copy of :func:`django.contrib.auth.models.update_last_login` @ Django 2.1.1
+
+    """
+    user.last_login = timezone.now()
+    user.save(update_fields=['last_login'])
+
 
 def get_or_create_system_user() -> 'User':
     """Return the "system user", which is created by itself.

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
             'docs',
             'tests*',
         ]),
-    python_requires='>=3.7, <3.10',
+    python_requires='>=3.7, <3.11',
     include_package_data=True,
     package_data=_package_data,
     install_requires=[
@@ -84,5 +84,6 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,24 @@
+from django.contrib.auth import signals
+from django.test import TestCase
+from django.test.client import RequestFactory
+from fd_dj_accounts.models import User
+
+
+class SignalTestCase(TestCase):
+
+    def test_update_last_login(self) -> None:
+        """Only `last_login` is updated in `update_last_login`"""
+        user = User.objects.create_user(email_address='staff@a.com', password='password')
+        self.assertIsNone(user.last_login)
+
+        request = RequestFactory().get('/login')
+        signals.user_logged_in.send(sender=user.__class__, request=request, user=user)
+        self.assertIsNotNone(user.last_login)
+
+        old_last_login = user.last_login
+        request = RequestFactory().get('/login')
+        signals.user_logged_in.send(sender=user.__class__, request=request, user=user)
+        user.refresh_from_db()
+
+        self.assertEqual(user.get_username(), 'staff@a.com')
+        self.assertGreater(user.last_login, old_last_login)

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 envlist =
     py37,
     py38,
+    py39,
+    py310,
 
 [testenv]
 setenv =
@@ -13,3 +15,4 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10


### PR DESCRIPTION
- (PR #197, 2022-12-20) chore: Update `last_login` field on User model
- (PR #199, 2023-01-04) chore: Add support for Python 3.10