### PR TITLE
Release v0.6.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0
+current_version = 0.6.0
 commit = True
 tag = False
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,14 @@ History
 unreleased (YYYY-MM-DD)
 +++++++++++++++++++++++
 
+0.6.0 (2023-03-14)
+++++++++++++++++++
+
+- (PR #218, 2023-03-08) Drop support for Python 3.7
+- (PR #209, 2023-03-14) chore(deps): bump coverage from 7.1.0 to 7.2.1
+- (PR #219, 2023-03-14) chore(deps): bump setuptools from 67.1.0 to 67.6.0
+- (PR #220, 2023-03-14) chore: bump actions/cache from 3.2.5 to 3.3.1
+
 0.5.0 (2023-03-07)
 ++++++++++++++++++
 

--- a/fd_dj_accounts/__init__.py
+++ b/fd_dj_accounts/__init__.py
@@ -98,7 +98,7 @@ About customization of the Django user model
 """
 
 
-__version__ = '0.5.0'
+__version__ = '0.6.0'
 
 
 default_app_config = 'fd_dj_accounts.apps.AccountsAppConfig'


### PR DESCRIPTION
- (PR #218, 2023-03-08) Drop support for Python 3.7
- (PR #209, 2023-03-14) chore(deps): bump coverage from 7.1.0 to 7.2.1
- (PR #219, 2023-03-14) chore(deps): bump setuptools from 67.1.0 to 67.6.0
- (PR #220, 2023-03-14) chore: bump actions/cache from 3.2.5 to 3.3.1