### PR TITLE
Add improved `__repr__()` to `User` model

### DIFF
--- a/fd_dj_accounts/models.py
+++ b/fd_dj_accounts/models.py
@@ -118,6 +118,7 @@ class User(base_models.BaseUser):
     - Override :meth:`save` to make sure full validation is performed before
       each and every save (including creation).
     - Custom model manager.
+    - Custom :meth:`__repr__` that includes the user’s ``id`` in addition to the username.
 
     .. seealso:: :class:`AnonymousUser`.
 
@@ -145,6 +146,16 @@ class User(base_models.BaseUser):
 
         verbose_name = 'user'
         verbose_name_plural = 'users'
+
+    def __repr__(self) -> str:
+        # fmt: off
+        return (
+            f"<{self.__class__.__name__}("
+            f"id={self.id!r},"
+            f" {self.USERNAME_FIELD}={self.get_username()!r}"
+            f")>"
+        )
+        # fmt: on
 
     def save(self, *args: Any, **kwargs: Any) -> None:
         """Call :meth:`full_clean` before saving."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from django.test import SimpleTestCase, TestCase
 
 from fd_dj_accounts.models import AnonymousUser, User, UserManager, get_or_create_system_user
@@ -82,6 +84,19 @@ class UserManagerTestCase(TestCase):
 
 
 class UserTestCase(TestCase):
+
+    def test_repr(self) -> None:
+        user = User(
+            id=UUID('12caf218-0001-45d4-b4df-44ff87f19989'),
+            email_address='user@example.com',
+        )
+        self.assertEqual(
+            repr(user),
+            "<User("
+            "id=UUID('12caf218-0001-45d4-b4df-44ff87f19989'),"
+            " email_address='user@example.com'"
+            ")>"
+        )
 
     def test_model_manager(self):  # type: ignore
         self.assertIsInstance(User.objects, UserManager)


### PR DESCRIPTION
Add custom method `User.__repr__()` that includes the `User’s` `id` in addition to the username.